### PR TITLE
Replace Brunch references with WebPack

### DIFF
--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -2,11 +2,11 @@
 using System.Runtime.InteropServices;
 using WebPackTaskRunner;
 
-[assembly: AssemblyTitle("Brunch Task Runner")]
-[assembly: AssemblyDescription("Adds support for the Brunch build tool in Visual Studio 2015's Task Runner Explorer.")]
+[assembly: AssemblyTitle("WebPack Task Runner")]
+[assembly: AssemblyDescription("Adds support for the WebPack build tool in Visual Studio 2015's Task Runner Explorer.")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Mads Kristensen")]
-[assembly: AssemblyProduct("Brunch Task Runner")]
+[assembly: AssemblyProduct("WebPack Task Runner")]
 [assembly: AssemblyCopyright("Copyright 2015 Mads Kristensen")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]

--- a/src/TaskRunner/TaskRunner.cs
+++ b/src/TaskRunner/TaskRunner.cs
@@ -26,7 +26,7 @@ namespace WebPackTaskRunner
             }
         }
 
-        private void InitializeBrunchRunnerOptions()
+        private void InitializeWebPackRunnerOptions()
         {
             _options = new List<ITaskRunnerOption>();
             _options.Add(new TaskRunnerOption("Display Modules", PackageIds.cmdDisplayModules, PackageGuids.guidWebPackPackageCmdSet, false, "--display-modules"));
@@ -41,7 +41,7 @@ namespace WebPackTaskRunner
             {
                 if (_options == null)
                 {
-                    InitializeBrunchRunnerOptions();
+                    InitializeWebPackRunnerOptions();
                 }
 
                 return _options;


### PR DESCRIPTION
There were some references to the Brunch task runner in a couple files. This PR replaces occurrences of Brunch with WebPack.
