### PR TITLE
Enforce consistency in quotes in item template

### DIFF
--- a/src/ItemTemplates/WebPack/webpack.config.js
+++ b/src/ItemTemplates/WebPack/webpack.config.js
@@ -4,15 +4,15 @@
         filename: "./dist/bundle.js"
     },
     devServer: {
-        contentBase: '.',
-        host: 'localhost',
+        contentBase: ".",
+        host: "localhost",
         port: 9000
     },
     module: {
         loaders: [
             {
                 test: /\.js$/,
-                loader: 'jsx-loader'
+                loader: "jsx-loader"
             },
         ]
     }


### PR DESCRIPTION
The WebPack item template associated with this extension mixes single and double quotes. This PR enforces consistency by switching all of them over to double quotes.
