### PR TITLE
Update item template name and description

### DIFF
--- a/src/ItemTemplates/WebPack/_Definitions/CSharp.vstemplate
+++ b/src/ItemTemplates/WebPack/_Definitions/CSharp.vstemplate
@@ -1,8 +1,8 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
     <TemplateData>
         <DefaultName>webpack.config.js</DefaultName>
-        <Name>WebPack Configuration file</Name>
-        <Description>WebPack Configuration file.</Description>
+        <Name>WebPack Configuration File</Name>
+        <Description>WebPack Configuration File</Description>
         <ProjectType>CSharp</ProjectType>
         <Icon>icon.png</Icon>
         <PreviewImage>preview.png</PreviewImage>

--- a/src/ItemTemplates/WebPack/_Definitions/Web.csharp.vstemplate
+++ b/src/ItemTemplates/WebPack/_Definitions/Web.csharp.vstemplate
@@ -1,8 +1,8 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
     <TemplateData>
         <DefaultName>webpack.config.js</DefaultName>
-        <Name>WebPack Configuration file</Name>
-        <Description>WebPack Configuration file.</Description>
+        <Name>WebPack Configuration File</Name>
+        <Description>WebPack Configuration File</Description>
         <ProjectType>Web</ProjectType>
         <ProjectSubType>CSharp</ProjectSubType>
         <Icon>icon.png</Icon>


### PR DESCRIPTION
The item template name and description are inconsistent with how similar item templates (e.g., Grunt and Gulp) are displayed. This PR enforces consistency.
