### PR TITLE
Enforce strict mode in webpack.config.js

### DIFF
--- a/src/ItemTemplates/WebPack/webpack.config.js
+++ b/src/ItemTemplates/WebPack/webpack.config.js
@@ -1,4 +1,6 @@
-﻿module.exports = {
+﻿"use strict";
+
+module.exports = {
     entry: "./src/file.js",
     output: {
         filename: "./dist/bundle.js"


### PR DESCRIPTION
This PR enables strict mode in the `webpack.config.js` file which is added via the item template. This change will disallow bad practices in JavaScript, such as `with` and `eval`.
