### PR TITLE
Adjust JSX loader configuration

### DIFF
--- a/src/ItemTemplates/WebPack/webpack.config.js
+++ b/src/ItemTemplates/WebPack/webpack.config.js
@@ -11,9 +11,9 @@
     module: {
         loaders: [
             {
-                test: /\.js$/,
-                loader: "jsx-loader"
-            },
+                test: /\.jsx?$/,
+                loader: "babel-loader"
+            }
         ]
     }
 }


### PR DESCRIPTION
This PR includes the following 3 changes to the JSX loader configuration in the WebPack configuration file:
1. Remove the trailing comma, as it is bound to cause someone problems when using JSHint, ESLint, etc.
2. Drop `jsx-loader` in favor of `babel-loader`, as Babel is the JSX compilation tool now used internally at Facebook
3. Adjust the loader regex to work with both `.js` and `.jsx` file extensions, as opposed to just `.js`
