### PR TITLE
Adjust the setting of NODE_ENV variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ When executing a Production task, the extension will automatically
 set `NODE_ENV` to *production*. For Development tasks,
 *development* will be the value.
 
-`SET NODE_ENV=production && webpack...`
+`SET NODE_ENV=production&& webpack...`
 
 ### Bindings
 Task bindings make it possible to associate individual tasks

--- a/src/TaskRunner/TaskRunner.cs
+++ b/src/TaskRunner/TaskRunner.cs
@@ -69,40 +69,40 @@ namespace WebPackTaskRunner
 
             // Run
             TaskRunnerNode build = new TaskRunnerNode("Run", false);
-            TaskRunnerNode buildDev = CreateTask(cwd, "Development", "Runs 'webpack -d'", "/c SET NODE_ENV=development && webpack -d --colors");
+            TaskRunnerNode buildDev = CreateTask(cwd, "Development", "Runs 'webpack -d'", "/c SET NODE_ENV=development&& webpack -d --colors");
             build.Children.Add(buildDev);
 
-            TaskRunnerNode buildProd = CreateTask(cwd, "Production", "Runs 'webpack -p'", "/c SET NODE_ENV=production && webpack -p --colors");
+            TaskRunnerNode buildProd = CreateTask(cwd, "Production", "Runs 'webpack -p'", "/c SET NODE_ENV=production&& webpack -p --colors");
             build.Children.Add(buildProd);
 
             root.Children.Add(build);
 
             // Profile
             TaskRunnerNode profile = new TaskRunnerNode("Profile", false);
-            TaskRunnerNode profileDev = CreateTask(cwd, "Development", "Runs 'webpack --profile'", "/c SET NODE_ENV=development && webpack -d --profile --json > stats.json && echo \x1B[32mThe analyse tool JSON file can be found at ./stats.json. Upload the file at http://webpack.github.io/analyse/.");
+            TaskRunnerNode profileDev = CreateTask(cwd, "Development", "Runs 'webpack --profile'", "/c SET NODE_ENV=development&& webpack -d --profile --json > stats.json && echo \x1B[32mThe analyse tool JSON file can be found at ./stats.json. Upload the file at http://webpack.github.io/analyse/.");
             profile.Children.Add(profileDev);
 
-            TaskRunnerNode profileProd = CreateTask(cwd, "Production", "Runs 'webpack --profile'", "/c SET NODE_ENV=production && webpack -p --profile --json > stats.json && echo \x1B[32mThe analyse tool JSON file can be found at ./stats.json. Upload the file at http://webpack.github.io/analyse/.");
+            TaskRunnerNode profileProd = CreateTask(cwd, "Production", "Runs 'webpack --profile'", "/c SET NODE_ENV=production&& webpack -p --profile --json > stats.json && echo \x1B[32mThe analyse tool JSON file can be found at ./stats.json. Upload the file at http://webpack.github.io/analyse/.");
             profile.Children.Add(profileProd);
 
             root.Children.Add(profile);
 
             // Start
             TaskRunnerNode start = new TaskRunnerNode("Serve", false);
-            TaskRunnerNode startDev = CreateTask(cwd, "Hot", "Runs 'webpack-dev-server --hot'", "/c SET NODE_ENV=development && webpack-dev-server --hot --colors");
+            TaskRunnerNode startDev = CreateTask(cwd, "Hot", "Runs 'webpack-dev-server --hot'", "/c SET NODE_ENV=development&& webpack-dev-server --hot --colors");
             start.Children.Add(startDev);
 
-            TaskRunnerNode startProd = CreateTask(cwd, "Cold", "Runs 'webpack-dev-server'", "/c SET NODE_ENV=development && webpack-dev-server --colors");
+            TaskRunnerNode startProd = CreateTask(cwd, "Cold", "Runs 'webpack-dev-server'", "/c SET NODE_ENV=development&& webpack-dev-server --colors");
             start.Children.Add(startProd);
 
             root.Children.Add(start);
 
             // Watch
             TaskRunnerNode watch = new TaskRunnerNode("Watch", false);
-            TaskRunnerNode watchDev = CreateTask(cwd, "Development", "Runs 'webpack -d --watch'", "/c SET NODE_ENV=development && webpack -d --watch --colors");
+            TaskRunnerNode watchDev = CreateTask(cwd, "Development", "Runs 'webpack -d --watch'", "/c SET NODE_ENV=development&& webpack -d --watch --colors");
             watch.Children.Add(watchDev);
 
-            TaskRunnerNode watchProd = CreateTask(cwd, "Production", "Runs 'webpack -p --watch'", "/c SET NODE_ENV=production && webpack -p --watch --colors");
+            TaskRunnerNode watchProd = CreateTask(cwd, "Production", "Runs 'webpack -p --watch'", "/c SET NODE_ENV=production&& webpack -p --watch --colors");
             watch.Children.Add(watchProd);
 
             root.Children.Add(watch);


### PR DESCRIPTION
The extension currently sets the `NODE_ENV` variable as follows:

```
SET NODE_ENV=development && ...
```

The space before the double ampersand causes the variable's value to include a trailing space. Here's an example of where it caused me trouble:

![wptr_defect](https://cloud.githubusercontent.com/assets/10702007/11966668/ce7f04e2-a8c2-11e5-8eb4-3c5e0dd7c06f.png)

I build the config file name based on the value of `NODE_ENV`. This PR eliminates the space before the double ampersand.
