### PR TITLE
Prepend parent name to child task name

### DIFF
--- a/src/TaskRunner/TaskRunner.cs
+++ b/src/TaskRunner/TaskRunner.cs
@@ -67,22 +67,25 @@ namespace WebPackTaskRunner
 
             ITaskRunnerNode root = new TaskRunnerNode(Constants.TASK_CATEGORY);
 
+            const string DEVELOPMENT_TASK_NAME = "Development";
+            const string PRODUCTION_TASK_NAME = "Production";
+
             // Run
             TaskRunnerNode build = new TaskRunnerNode("Run", false);
-            TaskRunnerNode buildDev = CreateTask(cwd, "Development", "Runs 'webpack -d'", "/c SET NODE_ENV=development&& webpack -d --colors");
+            TaskRunnerNode buildDev = CreateTask(cwd, $"{build.Name} - {DEVELOPMENT_TASK_NAME}", "Runs 'webpack -d'", "/c SET NODE_ENV=development&& webpack -d --colors");
             build.Children.Add(buildDev);
 
-            TaskRunnerNode buildProd = CreateTask(cwd, "Production", "Runs 'webpack -p'", "/c SET NODE_ENV=production&& webpack -p --colors");
+            TaskRunnerNode buildProd = CreateTask(cwd, $"{build.Name} - {PRODUCTION_TASK_NAME}", "Runs 'webpack -p'", "/c SET NODE_ENV=production&& webpack -p --colors");
             build.Children.Add(buildProd);
 
             root.Children.Add(build);
 
             // Profile
             TaskRunnerNode profile = new TaskRunnerNode("Profile", false);
-            TaskRunnerNode profileDev = CreateTask(cwd, "Development", "Runs 'webpack --profile'", "/c SET NODE_ENV=development&& webpack -d --profile --json > stats.json && echo \x1B[32mThe analyse tool JSON file can be found at ./stats.json. Upload the file at http://webpack.github.io/analyse/.");
+            TaskRunnerNode profileDev = CreateTask(cwd, $"{profile.Name} - {DEVELOPMENT_TASK_NAME}", "Runs 'webpack --profile'", "/c SET NODE_ENV=development&& webpack -d --profile --json > stats.json && echo \x1B[32mThe analyse tool JSON file can be found at ./stats.json. Upload the file at http://webpack.github.io/analyse/.");
             profile.Children.Add(profileDev);
 
-            TaskRunnerNode profileProd = CreateTask(cwd, "Production", "Runs 'webpack --profile'", "/c SET NODE_ENV=production&& webpack -p --profile --json > stats.json && echo \x1B[32mThe analyse tool JSON file can be found at ./stats.json. Upload the file at http://webpack.github.io/analyse/.");
+            TaskRunnerNode profileProd = CreateTask(cwd, $"{profile.Name} - {PRODUCTION_TASK_NAME}", "Runs 'webpack --profile'", "/c SET NODE_ENV=production&& webpack -p --profile --json > stats.json && echo \x1B[32mThe analyse tool JSON file can be found at ./stats.json. Upload the file at http://webpack.github.io/analyse/.");
             profile.Children.Add(profileProd);
 
             root.Children.Add(profile);
@@ -99,10 +102,10 @@ namespace WebPackTaskRunner
 
             // Watch
             TaskRunnerNode watch = new TaskRunnerNode("Watch", false);
-            TaskRunnerNode watchDev = CreateTask(cwd, "Development", "Runs 'webpack -d --watch'", "/c SET NODE_ENV=development&& webpack -d --watch --colors");
+            TaskRunnerNode watchDev = CreateTask(cwd, $"{watch.Name} - {DEVELOPMENT_TASK_NAME}", "Runs 'webpack -d --watch'", "/c SET NODE_ENV=development&& webpack -d --watch --colors");
             watch.Children.Add(watchDev);
 
-            TaskRunnerNode watchProd = CreateTask(cwd, "Production", "Runs 'webpack -p --watch'", "/c SET NODE_ENV=production&& webpack -p --watch --colors");
+            TaskRunnerNode watchProd = CreateTask(cwd, $"{watch.Name} - {PRODUCTION_TASK_NAME}", "Runs 'webpack -p --watch'", "/c SET NODE_ENV=production&& webpack -p --watch --colors");
             watch.Children.Add(watchProd);
 
             root.Children.Add(watch);


### PR DESCRIPTION
This PR addresses issue https://github.com/madskristensen/WebPackTaskRunner/issues/9. With these changes, task names are made unique by prepending the parent name. The user will see this:

![pr](https://cloud.githubusercontent.com/assets/10702007/12029311/6716cb42-adad-11e5-82ee-bb8ed53ef4c3.png)
