### PR TITLE
Removed --color and added --inline to Serve tasks

### DIFF
--- a/src/TaskRunner/TaskRunner.cs
+++ b/src/TaskRunner/TaskRunner.cs
@@ -91,10 +91,10 @@ namespace WebPackTaskRunner
 
             // Start
             TaskRunnerNode start = new TaskRunnerNode("Serve", false);
-            TaskRunnerNode startDev = CreateTask(cwd, "Hot", "Runs 'webpack-dev-server --hot'", "/c SET NODE_ENV=development&& webpack-dev-server --hot --color");
+            TaskRunnerNode startDev = CreateTask(cwd, "Hot", "Runs 'webpack-dev-server --hot'", "/c SET NODE_ENV=development&& webpack-dev-server --hot --inline");
             start.Children.Add(startDev);
 
-            TaskRunnerNode startProd = CreateTask(cwd, "Cold", "Runs 'webpack-dev-server'", "/c SET NODE_ENV=development&& webpack-dev-server --color");
+            TaskRunnerNode startProd = CreateTask(cwd, "Cold", "Runs 'webpack-dev-server'", "/c SET NODE_ENV=development&& webpack-dev-server --inline");
             start.Children.Add(startProd);
 
             root.Children.Add(start);


### PR DESCRIPTION
"--color" causes an error for me and doesn't work.  I normally use webpack 2 now in beta but tried with webpack 1 and it didn't work either.  I added --inline to enable live reload as well as asked for by a couple other commenters.
