### PR TITLE
Add support for `webpack.config.mjs` (ES6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ WebPack configuration files. The following file names
 are supported:
 
 - webpack.config.js
+- webpack.config.mjs
 - webpack.config.ts
 - webpack.config.coffee
 - webpack.config.babel.js

--- a/src/TaskRunner/TaskRunner.cs
+++ b/src/TaskRunner/TaskRunner.cs
@@ -11,7 +11,7 @@ using System.Windows.Media.Imaging;
 
 namespace WebPackTaskRunner
 {
-    [TaskRunnerExport("webpack.config.js", "webpack.config.babel.js", "webpack.config.ts", "webpack.config.coffee")]
+    [TaskRunnerExport("webpack.config.js", "webpack.config.mjs", "webpack.config.babel.js", "webpack.config.ts", "webpack.config.coffee")]
     internal class TaskRunner : ITaskRunner
     {
         private static ImageSource _icon;


### PR DESCRIPTION
Webpack 5 supports configuration files written with ES6 module syntax, per:
- https://github.com/webpack/webpack/issues/1403
- https://github.com/webpack/webpack/issues/1403#issuecomment-799346606

After switching over to this, I noticed that WebPackTaskRunner doesn't detect and support the `.mjs` configuration file.
This PR attempts to adds the missing bits.